### PR TITLE
Update init

### DIFF
--- a/jobs/postgresql-blacksmith-plans/templates/plans/cluster/init
+++ b/jobs/postgresql-blacksmith-plans/templates/plans/cluster/init
@@ -3,9 +3,9 @@ set -eu
 
 # init - Bootstrap Script for Postgresql Forge.
 #           Generates username and password for the
-#           new Redis environment.
+#           new Postgresql environment.
 
-safe gen -l 16 ${CREDENTIALS}/postgresql username
+safe gen 16 ${CREDENTIALS}/postgresql username
 safe gen       ${CREDENTIALS}/postgresql password
 
 exit 0


### PR DESCRIPTION
Safe syntax was wrong and causing errors when deploying postgresql services.  Removed the '-l' safe flag that signified a length for the username.  The flag isn't needed, just the length desired.  Would get this error in the blacksmith log when deploying postgresql:
`2018-08-29 18:48:51.139 DEBUG  init script `/var/vcap/data/blacksmith/postgresql-forge/services/small-cluster/init' said:
USAGE: gen [length] path key`

Also replaced redis with postgresql in the comments to avoid confusion.