### PR TITLE
Fixed the override for the persistent 'disk' in cluster manifest

### DIFF
--- a/jobs/postgresql-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/postgresql-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -41,7 +41,7 @@ instance_groups:
     stemcell: default
 
     vm_type: (( grab meta.size ))
-    persistent_disk_type: default
+    persistent_disk_type: (( grab meta.disk ))
 
     jobs:
       - name:    postgres

--- a/jobs/postgresql-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/postgresql-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -2,7 +2,7 @@
 meta:
   size: default
   default:
-    az: z1
+    azs: z1
   service:
     username: (( vault $CREDENTIALS "/postgresql:username" ))
     password: (( vault $CREDENTIALS "/postgresql:password" ))
@@ -35,7 +35,7 @@ update:
 instance_groups:
   - name: postgresql
     instances: 1
-    azs: [(( grab meta.az || meta.default.az ))]
+    azs: [(( grab meta.azs || meta.default.azs ))]
     networks: [name: (( grab meta.net || "postgresql-service" ))]
     stemcell: default
 


### PR DESCRIPTION
For consistency, I replaced the existing line in the **_cluster_** manifest.yml with the line from the **_standalone_** manifest.yml (as it allowed for the override).

I also changed the **_standalone_** manifest.yml to be consistent with the usage of **_azs_** in the config-blacksmith