### PR TITLE
Bump cluster manifest to postgres-boshrelease 3.1.5

### DIFF
--- a/jobs/postgresql-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/postgresql-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -1,7 +1,7 @@
 ---
 meta:
   size: default
-  instances: 3
+  instances: 2
   default:
     azs: [z1,z2]
   service:
@@ -18,9 +18,9 @@ meta:
 
 releases:
   - name: postgres
-    version: 2.0.0
-    url: https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v2.0.0/postgres-2.0.0.tgz
-    sha1: dea5cad517c62afaf97a1b31df41ad691928d960
+    version: 3.1.5
+    url: https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v3.1.5/postgres-3.1.5.tgz
+    sha1: 30feaf3522b205812f3d363380dee57d20e5e32a
 
 stemcells:
 - alias: default
@@ -58,21 +58,4 @@ instance_groups:
             replication:
               enabled: true
             hba:   (( grab meta.hba ))
-          pgpool:
             users: (( grab meta.users ))
-
-      - name: pgpool
-        release: postgres
-        consumes:
-          db: {from: postgres}
-        properties:
-          pgpool:
-            backend:
-              port: 6432
-            config:
-              port: (( grab meta.service.port ))
-              enable_pool_hba: on
-            hba: (( grab meta.hba ))
-            users: (( grab meta.users ))
-          pcp:
-            system_password: secret


### PR DESCRIPTION
This is an apologetically amateurish attempt to bump the version on the cluster manifest to 3.1.5. I managed to deploy this manifest locally on a BOSH lite director, and verified that I was able to create a database on one node and see that mirrored on the other. It _seems_ to work.

`pgpool` is not a job in 3.1.5, and so has been dropped from the manifest (afraid I'm not sufficiently familiar with Postgres to know whether that's an issue), and I decreased the number of instances to two after receiving an error saying that with replication enabled you should _never_ have three instances.