### PR TITLE
Update required for postgres-boshrelease 3.2.1 change

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Bug fix
+
+Moved the user credentials to new location needed for postgres-boshrelease 3.2.1 change

--- a/jobs/postgresql-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/postgresql-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -55,3 +55,7 @@ instance_groups:
               listen_addresses: 0.0.0.0
               port: (( grab meta.service.port ))
             hba:   (( grab meta.hba ))
+            users:
+            - username: (( grab meta.service.username ))
+              password: (( grab meta.service.password ))
+              admin: true


### PR DESCRIPTION
The change to postgres-boshrelease wants the user/password in a different location.